### PR TITLE
fix: ignore *.scss modules while loading stories

### DIFF
--- a/src/creevey.ts
+++ b/src/creevey.ts
@@ -20,6 +20,7 @@ addHook(() => '', {
     '.css',
     '.less',
     '.sass',
+    '.scss',
     '.styl',
   ],
   ignoreNodeModules: false,


### PR DESCRIPTION
Очень надо.