### PR TITLE
fix: 🐛 loader: remove vars in desctructuring

### DIFF
--- a/src/server/master/loader.ts
+++ b/src/server/master/loader.ts
@@ -91,7 +91,7 @@ function recursivelyRemoveUnreferencedBindings(path: NodePath<t.Program>): void 
   };
   let bindings = getUnreferencedBindings();
   do {
-    bindings.forEach((binding) => binding.path.remove());
+    bindings.forEach((binding) => !binding.path.removed && binding.path.remove());
   } while ((bindings = getUnreferencedBindings()).length > 0);
 }
 

--- a/tests/server/master/loader.fixtures/destructuring.input.tsx
+++ b/tests/server/master/loader.fixtures/destructuring.input.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+import React from 'react';
+import { storiesOf } from '@storybook/react';
+
+import { someMethod } from './src/someMethod';
+
+const { a, b, c } = someMethod();
+
+storiesOf(module).add('Text', () => <button>Hello Button</button>);

--- a/tests/server/master/loader.fixtures/destructuring.output.tsx
+++ b/tests/server/master/loader.fixtures/destructuring.output.tsx
@@ -1,0 +1,9 @@
+// @ts-nocheck
+
+import { storiesOf } from '@storybook/react';
+
+
+
+
+
+storiesOf(module).add('Text', () => {});


### PR DESCRIPTION
all vars referenced to one object that was deleted with first var