### PR TITLE
feat: allow to set storybook's globals

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -76,6 +76,11 @@ module.exports = {
       limit: 2,
       /* Also you can define any browser capabilities here */
       version: '86.0',
+      // It's possible to set Storybook's globals
+      // https://github.com/storybookjs/storybook/blob/v6.0.0/docs/essentials/toolbars-and-globals.md
+      storybookGlobals: {
+        myTheme: 'dark',
+      },
     },
 
     // You can override some global options for specific browser

--- a/docs/config.md
+++ b/docs/config.md
@@ -78,7 +78,8 @@ module.exports = {
       version: '86.0',
       // It's possible to set Storybook's globals
       // https://github.com/storybookjs/storybook/blob/v6.0.0/docs/essentials/toolbars-and-globals.md
-      storybookGlobals: {
+      // NOTE: This is an experimental feature and will be replaced in future
+      _storybookGlobals: {
         myTheme: 'dark',
       },
     },

--- a/src/client/addon/decorator.ts
+++ b/src/client/addon/decorator.ts
@@ -1,6 +1,6 @@
 import Events from '@storybook/core-events';
 import { addons, MakeDecoratorResult, makeDecorator } from '@storybook/addons';
-import { isObject } from '../../types';
+import { isObject, StorybookGlobals } from '../../types';
 
 if (typeof process != 'object' || typeof process.version != 'string') {
   // NOTE If you don't use babel-polyfill or any other polyfills that add EventSource for IE11
@@ -15,6 +15,7 @@ if (typeof process != 'object' || typeof process.version != 'string') {
 declare global {
   interface Window {
     __CREEVEY_SELECT_STORY__: (storyId: string, kind: string, name: string, callback: (error?: string) => void) => void;
+    __CREEVEY_UPDATE_GLOBALS__: (globals: StorybookGlobals) => void;
   }
 
   interface Document {
@@ -159,7 +160,12 @@ export function withCreevey(): MakeDecoratorResult {
     }
   }
 
+  function updateGlobals(globals: StorybookGlobals): void {
+    addons.getChannel().emit(Events.UPDATE_GLOBALS, { globals });
+  }
+
   window.__CREEVEY_SELECT_STORY__ = selectStory;
+  window.__CREEVEY_UPDATE_GLOBALS__ = updateGlobals;
 
   return makeDecorator({
     name: 'withCreevey',

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -296,6 +296,7 @@ export async function getBrowser(config: Config, browserConfig: BrowserConfig): 
     storybookUrl: address = config.storybookUrl,
     limit,
     viewport,
+    _storybookGlobals,
     ...userCapabilities
   } = browserConfig;
   void limit;
@@ -334,6 +335,10 @@ export async function getBrowser(config: Config, browserConfig: BrowserConfig): 
     const error = new Error(`Can't load storybook root page by URL ${realAddress}/iframe.html`);
     if (originalError instanceof Error) error.stack = originalError.stack;
     throw error;
+  }
+
+  if (_storybookGlobals) {
+    await updateStorybookGlobals(browser, _storybookGlobals);
   }
 
   return browser;

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -1,7 +1,7 @@
 import { PNG } from 'pngjs';
 import { Context, Test, Suite } from 'mocha';
 import { Builder, By, WebDriver, Origin, Capabilities } from 'selenium-webdriver';
-import { Config, BrowserConfig, StoryInput, CreeveyStoryParams, noop, isDefined } from '../../types';
+import { Config, BrowserConfig, StoryInput, CreeveyStoryParams, noop, isDefined, StorybookGlobals } from '../../types';
 import { subscribeOn } from '../messages';
 import { networkInterfaces } from 'os';
 import { runSequence, LOCALHOST_REGEXP } from '../utils';
@@ -282,6 +282,12 @@ async function selectStory(browser: WebDriver, storyId: string, kind: string, st
     story,
   );
   if (errorMessage) throw new Error(errorMessage);
+}
+
+export async function updateStorybookGlobals(browser: WebDriver, globals: StorybookGlobals): Promise<void> {
+  await browser.executeScript(function (globals: StorybookGlobals) {
+    window.__CREEVEY_UPDATE_GLOBALS__(globals);
+  }, globals);
 }
 
 export async function getBrowser(config: Config, browserConfig: BrowserConfig): Promise<WebDriver | null> {

--- a/src/server/selenium/browser.ts
+++ b/src/server/selenium/browser.ts
@@ -4,8 +4,9 @@ import { Builder, By, WebDriver, Origin, Capabilities } from 'selenium-webdriver
 import { Config, BrowserConfig, StoryInput, CreeveyStoryParams, noop, isDefined, StorybookGlobals } from '../../types';
 import { subscribeOn } from '../messages';
 import { networkInterfaces } from 'os';
-import { runSequence, LOCALHOST_REGEXP } from '../utils';
+import { runSequence, LOCALHOST_REGEXP, isStorybookVersionLessThan } from '../utils';
 import { PageLoadStrategy } from 'selenium-webdriver/lib/capabilities';
+import chalk from 'chalk';
 
 declare global {
   interface Window {
@@ -285,6 +286,12 @@ async function selectStory(browser: WebDriver, storyId: string, kind: string, st
 }
 
 export async function updateStorybookGlobals(browser: WebDriver, globals: StorybookGlobals): Promise<void> {
+  if (isStorybookVersionLessThan(6)) {
+    console.log(
+      chalk`[{yellow WARN}{gray :${process.pid}}] Globals are not supported by Storybook versions less than 6`,
+    );
+    return;
+  }
   await browser.executeScript(function (globals: StorybookGlobals) {
     window.__CREEVEY_UPDATE_GLOBALS__(globals);
   }, globals);

--- a/src/server/worker/worker.ts
+++ b/src/server/worker/worker.ts
@@ -8,7 +8,7 @@ import { Key } from 'selenium-webdriver';
 import { Config, Images, Options, BrowserConfig, TestMessage, isImageError } from '../../types';
 import { subscribeOn, emitTestMessage, emitWorkerMessage } from '../messages';
 import chaiImage from './chai-image';
-import { getBrowser, switchStory, updateStorybookGlobals } from '../selenium';
+import { getBrowser, switchStory } from '../selenium';
 import { CreeveyReporter, TeamcityReporter } from './reporter';
 import { addTestsFromStories } from './helpers';
 
@@ -154,10 +154,6 @@ export default async function worker(config: Config, options: Options & { browse
   );
 
   subscribeOn('shutdown', () => clearInterval(interval));
-
-  if (browserConfig.storybookGlobals) {
-    await updateStorybookGlobals(browser, browserConfig.storybookGlobals);
-  }
 
   mocha.suite.beforeAll(function (this: Context) {
     this.config = config;

--- a/src/server/worker/worker.ts
+++ b/src/server/worker/worker.ts
@@ -8,7 +8,7 @@ import { Key } from 'selenium-webdriver';
 import { Config, Images, Options, BrowserConfig, TestMessage, isImageError } from '../../types';
 import { subscribeOn, emitTestMessage, emitWorkerMessage } from '../messages';
 import chaiImage from './chai-image';
-import { getBrowser, switchStory } from '../selenium';
+import { getBrowser, switchStory, updateStorybookGlobals } from '../selenium';
 import { CreeveyReporter, TeamcityReporter } from './reporter';
 import { addTestsFromStories } from './helpers';
 
@@ -154,6 +154,10 @@ export default async function worker(config: Config, options: Options & { browse
   );
 
   subscribeOn('shutdown', () => clearInterval(interval));
+
+  if (browserConfig.storybookGlobals) {
+    await updateStorybookGlobals(browser, browserConfig.storybookGlobals);
+  }
 
   mocha.suite.beforeAll(function (this: Context) {
     this.config = config;

--- a/src/types.ts
+++ b/src/types.ts
@@ -90,6 +90,11 @@ export type BrowserConfig = Capabilities & {
   gridUrl?: string;
   storybookUrl?: string;
   /**
+   * Storybook's globals to set in a specific browser
+   * @see https://github.com/storybookjs/storybook/blob/v6.0.0/docs/essentials/toolbars-and-globals.md
+   */
+  storybookGlobals?: StorybookGlobals;
+  /**
    * Specify custom docker image. Used only with `useDocker == true`
    * @default `selenoid/${browserName}:${version}`
    */
@@ -101,6 +106,10 @@ export type BrowserConfig = Capabilities & {
   webdriverCommand?: string[];
   viewport?: { width: number; height: number };
 };
+
+export interface StorybookGlobals {
+  [key: string]: unknown;
+}
 
 export type Browser = boolean | string | BrowserConfig;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export type BrowserConfig = Capabilities & {
    * Storybook's globals to set in a specific browser
    * @see https://github.com/storybookjs/storybook/blob/v6.0.0/docs/essentials/toolbars-and-globals.md
    */
-  storybookGlobals?: StorybookGlobals;
+  _storybookGlobals?: StorybookGlobals;
   /**
    * Specify custom docker image. Used only with `useDocker == true`
    * @default `selenoid/${browserName}:${version}`


### PR DESCRIPTION
Добавил возможность передать в браузеры значения [Globals](https://storybook.js.org/docs/react/essentials/toolbars-and-globals). Это глобальные и изменяемые настройки в storybook@6+, которые доступны в декораторах и историях. Их можно менять в любой момент, истории автоматически ререндерятся. 

Например, с помощью Globals и соответствующего декоратора можно настроить тему для всех компонентов сразу. И переключать ее в любой момент из аддона или тулбара (см. примеры по ссылке).

Правка позволяет pазным браузерам задавать разные значения. Что дает возможность тестировать разные темы параллельно на одном инстансе сторибука. Это очень актуально для retail-ui, где мы уже вплотную приблизились к запуску четырех сторибуков с разными настройками для тестирования четырех разных тем.

 