### PR TITLE
chore(docs): hermione support tests hot-reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ MyModalStory.parameters = { creevey: { captureElement: null } };
 | Test Interaction            | :heavy_check_mark: | :no_entry:         | :warning:          | :heavy_check_mark: | :heavy_check_mark: | :no_entry:         | :no_entry:         |
 | UI Test Runner              | :heavy_check_mark: | :no_entry:         | :no_entry:         | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: | :heavy_check_mark: |
 | Built-in Docker             | :heavy_check_mark: | :heavy_check_mark: | :no_entry:         | :no_entry:         | :heavy_check_mark: | :warning:          | :warning:          |
-| Tests hot-reload            | :heavy_check_mark: | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         | :no_entry:         |
+| Tests hot-reload            | :heavy_check_mark: | :no_entry:         | :no_entry:         | :heavy_check_mark: | :no_entry:         | :no_entry:         | :no_entry:         |
 | OSS/SaaS                    | OSS                | OSS                | OSS                | OSS                | OSS                | SaaS               | SaaS               |
 
 ## Future plans


### PR DESCRIPTION
Did I understand correctly that expression "tests hot-reload" means that when you change the test, you do not need to restart the test tool, because the changes in the test are applied immediately? If yes, then hermione is already support it.

Moreover what is meant the expression "Storybook Support"? If at all the ability to run storybook-tests then hermione support it too. We already use hermione for it, but we don't have any addons for storybook for more convenience configuration.