### PR TITLE
Add support for MicrosoftEdge

### DIFF
--- a/src/server/selenium/selenoid.ts
+++ b/src/server/selenium/selenoid.ts
@@ -35,7 +35,7 @@ async function createSelenoidConfig(browsers: BrowserConfig[], { useDocker }: { 
       selenoidConfig[browserName].versions[version] = {
         image: useDocker ? dockerImage : webdriverCommand,
         port: '4444',
-        path: !useDocker || ['chrome', 'opera', 'webkit'].includes(browserName) ? '/' : '/wd/hub',
+        path: !useDocker || ['chrome', 'opera', 'webkit', 'MicrosoftEdge'].includes(browserName) ? '/' : '/wd/hub',
       };
     },
   );


### PR DESCRIPTION
Add MicrosoftEdge to browser list to use path '/'
Follow rules for this images : https://aerokube.com/images/latest/#_microsoft_edge

```javascript
'edge.desktop': {
      browserName: 'MicrosoftEdge',
      dockerImage: edgeDockerImage,
      viewport: { height: 768, width: 1366 },
    },
```